### PR TITLE
Fix get_moments tip-side load extrapolation

### DIFF
--- a/src/fatigue_model.jl
+++ b/src/fatigue_model.jl
@@ -424,8 +424,8 @@ function get_moments(out,Rhub,Rtip,r,az,precone,tilt)
     m_flap = dL_flap/dr
     m_edge = dL_edge/dr
 
-    Lhub_flap = loads_flap[end] + m_flap*(Rtip-r_arr[end-1])
-    Lhub_edge = loads_edge[end] + m_edge*(Rtip-r_arr[end-1])
+    Lhub_flap = loads_flap[end-1] + m_flap*(Rtip-r_arr[end-1])
+    Lhub_edge = loads_edge[end-1] + m_edge*(Rtip-r_arr[end-1])
 
     loads_flap[end] = Lhub_flap
     loads_edge[end] = Lhub_edge

--- a/src/fatigue_model.jl
+++ b/src/fatigue_model.jl
@@ -424,11 +424,11 @@ function get_moments(out,Rhub,Rtip,r,az,precone,tilt)
     m_flap = dL_flap/dr
     m_edge = dL_edge/dr
 
-    Lhub_flap = loads_flap[end-1] + m_flap*(Rtip-r_arr[end-1])
-    Lhub_edge = loads_edge[end-1] + m_edge*(Rtip-r_arr[end-1])
+    Ltip_flap = loads_flap[end-1] + m_flap*(Rtip-r_arr[end-1])
+    Ltip_edge = loads_edge[end-1] + m_edge*(Rtip-r_arr[end-1])
 
-    loads_flap[end] = Lhub_flap
-    loads_edge[end] = Lhub_edge
+    loads_flap[end] = Ltip_flap
+    loads_edge[end] = Ltip_edge
     r_arr[end] = Rtip
 
     M_flap = trapz(r_arr,loads_flap.*(r_arr.-Rhub))


### PR DESCRIPTION
The tip-side linear extrapolation in get_moments used loads_flap[end] (and loads_edge[end]) as the base value for the extrapolation. Those slots are still zero at this point... only loads_flap[2:end-1] has been populated from the per-station Np/Tp inputs. The hub-side block correctly uses loads_flap[2] as its base; the tip-side reads loads_flap[end-1] symmetrically, likely a copy-paste typo.

For constant input loads the bug zeros out the tip-load before trapezoidal integration, biasing M_flap / M_edge low (~5% on an NREL 5-MW geometry with 6 stations spanning 10–60 m).